### PR TITLE
Added time server description

### DIFF
--- a/repositories.md
+++ b/repositories.md
@@ -30,7 +30,7 @@ If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the follo
 #### Changes to the Director repository
 If a Time Server is in use, a representation of the Time Server public key is CONDITIONALLY REQUIRED in Director repository root metadata.
 
-If a Time Server is implemented AND partial-verification secondaries are used, the following metadata is CONDITIONALLY REQUIRED in the Director repository's Targets metadata:
+If a Time Server is implemented AND partial verification Secondaries are used, the following metadata is CONDITIONALLY REQUIRED in the Director repository's Targets metadata:
 
 * A representation of the public key(s) for the Time Server, similar to the representation of public keys in Root metadata.
 

--- a/repositories.md
+++ b/repositories.md
@@ -9,7 +9,9 @@ This page outlines recommended procedures for the one-time operations that an OE
 
 ## Secure Source of Time
 
-ECUs need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
+Without access to a secure source of time, ECUs may be prevented from receiving the most recent updates. If the ECU's time is too high, the ECU will detect that the current valid metadata is expired and will be unable to perform an update. If the ECU's time is too low, an attacker would be able to replay old metadata to the ECU and install an old, potentially insecure, version.
+
+To prevent these issues, ECUs need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
 
 ### Time server
 

--- a/repositories.md
+++ b/repositories.md
@@ -34,7 +34,7 @@ If a Time Server is implemented AND partial verification Secondaries are used, t
 
 * A representation of the public key(s) for the Time Server, similar to the representation of public keys in Root metadata.
 
-Listing the public key of the Time Server in Director Targets metadata is necessary to allow partial-verification Secondaries to perform Time Server key rotation.
+Listing the public key of the Time Server in Director Targets metadata is necessary to allow partial verification Secondaries to perform Time Server key rotation.
 
 #### Changes to a Primary
 

--- a/repositories.md
+++ b/repositories.md
@@ -13,7 +13,7 @@ ECUs need access to a secure source of time. If an ECU does not have a secure cl
 
 ### Time server
 
-A Time Server is a server that is responsible for the distribution of a secure source of time. 
+A Time Server is a server that is responsible for the distribution of a secure source of time.
 
 The Time Server exists to inform ECUs about the current time in a cryptographically secure way, since many ECUs in a vehicle do not have a reliable source of time. The Time Server receives a list of tokens from vehicles, and returns back a list of signed records containing every token in the original list of tokens received and at least one instance of the current time.
 
@@ -67,6 +67,9 @@ If any check fails, the ECU SHALL NOT overwrite its current attested time, and S
 
 In order to prevent a new timeserver from accidentally causing a rollback warning, the clock must be reset when switching to a new timeserver. To do this, check the Timeserver key after updating to the most recent Root metadata file. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
 
+#### Changes to Partial Verification Secondaries
+
+As partial verification secondaries only check the Targets metadata from the Director repository, the timeserver key must be checked when verifying the Targets metadata on partial verification secondaries. To do this, check the Timeserver key after verifying the most recent Targets metadata file. If the Timeserver key is listed in the Targets metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value as described in [Changes to checking Root metadata](#changes-to-checking-root-metadata).
 
 ## What suppliers should do
 

--- a/repositories.md
+++ b/repositories.md
@@ -5,9 +5,66 @@ css_id: repositories
 
 # Setting up Uptane repositories
 
-### TODO This section should be reviewed carefully, particularly anything dealing wtih the timeserver. I know what was stipulated for providing time has been changed, but I do not have the technical expertise to determine what should be deleted on this topic.
-
 This page outlines recommended procedures for the one-time operations that an OEM and its suppliers MUST perform when they set up Uptane for the first time. In particular, they SHOULD correctly configure the director and image repositories, as well as the time server, so that the impact of a repository / server compromise is limited to as few ECUs as possible.
+
+## Secure Source of Time
+
+Uptane repositories need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a time server can be used in an Uptane implementation.
+
+### Time server
+
+The Time Server exists to inform vehicles about the current time in a cryptographically secure way, since many ECUs in a vehicle will not have a reliable source of time. It receives lists of tokens from vehicles, and returns back a signed sequence that includes the token and the current time.
+
+If the time server is used, it MUST conform to the following requirements:
+
+* When the Time Server receives a sequence of tokens from a vehicle, it SHALL provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
+
+* The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
+
+* Rotation of the The Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the Director's Targets metadata (for partial verification secondaries).
+
+#### Changes to the Director repository
+If a Time Server is in use, a representation of the Time Server public key is CONDITIONALLY REQUIRED in Director repository root metadata.
+
+If a Time Server is implemented AND partial-verification secondaries will be used, the following metadata is CONDITIONALLY REQUIRED in the Director repository's Targets metadata:
+
+* A representation of the public key(s) for the Time Server, similar to the representation of public keys in Root metadata.
+
+Listing the public key of the Time Server in Director targets metadata is necessary to allow partial-verification secondaries to perform time server key rotation.
+
+#### Changes to a Primary
+
+If the time server is implemented, the primary SHALL use the following procedure to verify the time. This procedure will occur after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
+
+1. Gather the tokens from each secondary ECU's version report.
+2. Send the list of tokens to the time server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
+3. If the time server's response meets the criteria below, update the primary ECU's clock and retain the time server's response for distribution to secondary ECUs, otherwise discard it and proceed without an updated time.  The criteria for checking the time server's response are:
+  - The signature over the time server's response is valid.
+  - The tokens provided to the time server have been included in the response.
+  - The time in the time server's response is later than the last time verified in this manner.
+
+#### ECU Version Report
+
+The payload of the ECU version report should contain the latest time downloaded from the time server. In addition, the report should include a token (nonce) for the time server to sign and send back.
+
+#### Changes to all ECUs
+
+At build time, ECUs will be provisioned with an attestation of the current time downloaded from the time server.
+
+As the first step to verifying metadata, described as "Load and verify the current time or the most recent securely attested time" in the Standard, the ECU SHOULD load and verify the  most recent time from the time server using the following procedure:
+
+1. Verify that the signatures on the downloaded time are valid.
+2. Verify that the list of nonces/tokens in the downloaded time includes the token that the ECU sent in its previous version report.
+3. Verify that the time downloaded is greater than the previous time.
+
+If all three steps complete without error, the ECU SHALL overwrite its current attested time with the time it has just downloaded, and generate a new nonce/token for the next request to the time server.
+
+If any check fails, the ECU SHALL NOT overwrite its current attested time, and SHALL jump to the last step ([Create and Send Version Report](https://uptane.github.io/uptane-standard/uptane-standard.html#create_version_report)), and report the error. The ECU MUST reuse its previous token for the next request to the time server.
+
+#### Changes to checking Root metadata
+
+After updating to the most recent Root metadata file, check the Timeserver key. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
+
 
 ## What suppliers should do
 

--- a/repositories.md
+++ b/repositories.md
@@ -49,7 +49,7 @@ If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use 
 
 #### ECU Version Report
 
-The ECU version report from each Secondary will contain a token to be sent to the Time Server. This token SHOULD be unique for each update cycle to prevent a replay. As updates are relatively infrequent and there are a large number of possible tokens, the token will be able to be unique for every update.
+The ECU version report from each Secondary will contain a token to be sent to the Time Server. This token SHOULD be unique for each update cycle to prevent a replay. Since we expect updates to be relatively infrequent (e.g., due to limited number of write cycles), and that there are a large number of possible tokens, it should be possible to produce a unique token for every update.
 
 The payload of the ECU version report sent to the Director might contain the token sent to the Time Server. This token is in the version report sent from secondaries to the primary, and so is in the signed version of the version report. If the token is removed, the signature will not match.
 

--- a/repositories.md
+++ b/repositories.md
@@ -73,7 +73,7 @@ In order to prevent a new timeserver from accidentally causing a rollback warnin
 
 #### Changes to Partial Verification Secondaries
 
-As partial verification secondaries only check the Targets metadata from the Director repository, the timeserver key will be checked when verifying the Targets metadata on partial verification secondaries. To do this, check the Timeserver key after verifying the most recent Targets metadata file. If the Timeserver key is listed in the Targets metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value as described in [Changes to checking Root metadata](#changes-to-checking-root-metadata).
+As partial verification Secondaries only check the Targets metadata from the Director repository, the Time Server key will be checked when verifying the Targets metadata on partial verification Secondaries. To do this, check the Time Server key after verifying the most recent Targets metadata file. If the Time Server key is listed in the Targets metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value as described in [Changes to checking Root metadata](#changes-to-checking-root-metadata).
 
 ## What suppliers should do
 

--- a/repositories.md
+++ b/repositories.md
@@ -55,10 +55,10 @@ The payload of the ECU version report should contain the latest time downloaded 
 
 At build time, ECUs will be provisioned with an attestation of the current time downloaded from the Time Server.
 
-As the first step to verifying metadata, described as "Load and verify the current time or the most recent securely attested time" in the Standard, the ECU SHOULD load and verify the  most recent time from the Time Server using the following procedure:
+As the first step to verifying metadata, described as ["Load and verify the current time or the most recent securely attested time"](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#partial_verification) in the Standard, the ECU SHOULD load and verify the most recent time from the Time Server using the following procedure:
 
 1. Verify that the signatures on the downloaded time are valid.
-2. Verify that the list of tokens in the downloaded time includes the token that the ECU sent in its previous version report.
+2. Verify that the list of tokens in the downloaded time includes the token that the ECU sent in its version report.
 3. Verify that the time downloaded is greater than the previous time.
 
 If all three steps complete without error, the ECU is CONDITIONALLY REQUIRED to overwrite its current attested time with the time it has just downloaded, and generate a new token for the next request to the Time Server.

--- a/repositories.md
+++ b/repositories.md
@@ -41,7 +41,7 @@ Listing the public key of the Time Server in Director targets metadata is necess
 If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the ["Download and check current time"](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#check_time_primary) step of the Uptane Standard.
 
 1. Gather the tokens from each secondary ECU's version report.
-2. Send the list of tokens to the Time Server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
+2. Send the list of tokens to the Time Server to fetch the current time. The Time Server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
 3. If the Time Server's response meets the criteria below, update the primary ECU's clock and retain the Time Server's response for distribution to secondary ECUs, otherwise discard it and proceed without an updated time.  The criteria for checking the Time Server's response are:
   - The signature over the Time Server's response is valid.
   - All the tokens provided to the Time Server have been included in the response.
@@ -49,7 +49,7 @@ If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use 
 
 #### ECU Version Report
 
-The payload of the ECU version report should contain the latest time downloaded from the Time Server. In addition, the report should include a token (which SHOULD be used exactly once to prevent a replay attack) for the Time Server to sign and send back.
+The payload of the ECU version report sent to the Director might contain the token sent to the Time Server. This token is in the version report sent from secondaries to the primary, and so is in the signed version of the version report. If the token is removed, the signature will not match.
 
 #### Changes to all ECUs
 

--- a/repositories.md
+++ b/repositories.md
@@ -15,7 +15,7 @@ To prevent these issues, ECUs need access to a secure source of time. If an ECU 
 
 ### Time server
 
-A Time Server is a server that is responsible for the distribution of a secure source of time.
+A Time Server is a server that is responsible to act as a secure source of time.
 
 The Time Server exists to inform ECUs about the current time in a cryptographically secure way, since many ECUs in a vehicle do not have a reliable source of time. The Time Server receives a list of tokens from vehicles, and returns back a list of signed records containing every token in the original list of tokens received and at least one instance of the current time.
 

--- a/repositories.md
+++ b/repositories.md
@@ -45,7 +45,7 @@ If the Time Server is implemented, the primary SHALL use the following procedure
 
 #### ECU Version Report
 
-The payload of the ECU version report should contain the latest time downloaded from the Time Server. In addition, the report should include a token (nonce) for the Time Server to sign and send back.
+The payload of the ECU version report should contain the latest time downloaded from the Time Server. In addition, the report should include a token (which MUST be used exactly once) for the Time Server to sign and send back.
 
 #### Changes to all ECUs
 
@@ -63,7 +63,7 @@ If any check fails, the ECU SHALL NOT overwrite its current attested time, and S
 
 #### Changes to checking Root metadata
 
-After updating to the most recent Root metadata file, check the Timeserver key. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
+In order to prevent a new timeserver from accidentally causing a rollback warning, the clock must be reset when switching to a new timeserver. To do this, check the Timeserver key after updating to the most recent Root metadata file. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
 
 
 ## What suppliers should do

--- a/repositories.md
+++ b/repositories.md
@@ -34,7 +34,7 @@ If a Time Server is implemented AND partial-verification secondaries are used, t
 
 * A representation of the public key(s) for the Time Server, similar to the representation of public keys in Root metadata.
 
-Listing the public key of the Time Server in Director targets metadata is necessary to allow partial-verification secondaries to perform time server key rotation.
+Listing the public key of the Time Server in Director Targets metadata is necessary to allow partial-verification Secondaries to perform Time Server key rotation.
 
 #### Changes to a Primary
 

--- a/repositories.md
+++ b/repositories.md
@@ -15,7 +15,7 @@ To prevent these issues, ECUs need access to a secure source of time. If an ECU 
 
 ### Time server
 
-A Time Server is a server that is responsible to act as a secure source of time.
+A Time Server is a server that is responsible for providing a secure source of time.
 
 The Time Server exists to inform ECUs about the current time in a cryptographically secure way, since many ECUs in a vehicle do not have a reliable source of time. The Time Server receives a list of tokens from vehicles, and returns back a list of signed records containing every token in the original list of tokens received and at least one instance of the current time.
 

--- a/repositories.md
+++ b/repositories.md
@@ -25,7 +25,7 @@ If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the follo
 
 * The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, HTTPS, or another transport control of the implementor's choice.
 
-* Rotation of the The Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the Director's Targets metadata (for partial verification secondaries).
+* Rotation of the The Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the custom field of the Director Repository's Targets metadata (for partial verification secondaries).
 
 #### Changes to the Director repository
 If a Time Server is in use, a representation of the Time Server public key is CONDITIONALLY REQUIRED in Director repository root metadata.
@@ -38,7 +38,7 @@ Listing the public key of the Time Server in Director targets metadata is necess
 
 #### Changes to a Primary
 
-If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
+If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the ["Download and check current time"](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#check_time_primary) step of the Uptane Standard.
 
 1. Gather the tokens from each secondary ECU's version report.
 2. Send the list of tokens to the Time Server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.

--- a/repositories.md
+++ b/repositories.md
@@ -23,7 +23,7 @@ If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the follo
 
 * When the Time Server receives a sequence of tokens from a vehicle, it will provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
 
-* The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
+* The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, HTTPS, or another transport control of the implementor's choice.
 
 * Rotation of the The Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the Director's Targets metadata (for partial verification secondaries).
 

--- a/repositories.md
+++ b/repositories.md
@@ -9,7 +9,7 @@ This page outlines recommended procedures for the one-time operations that an OE
 
 ## Secure Source of Time
 
-Without access to a secure source of time, ECUs may be prevented from receiving the most recent updates. If the ECU's time is too high, the ECU will detect that the current valid metadata is expired and will be unable to perform an update. If the ECU's time is too low, an attacker can prevent time from moving forward significantly to replay old metadata to the ECU.  (ECUs in Uptane will not accept an earlier time than what has been seen before signed with the same key.)
+Without access to a secure source of time, ECUs may be prevented from receiving the most recent updates. If the ECU's time is too high, the ECU will detect that the current valid metadata is expired and will be unable to perform an update. If the ECU's time is too low, an attacker can freeze or replay old metadata to the ECU.  (ECUs in Uptane will not accept an earlier time than what has been seen before signed with the same key.)
 
 To prevent these issues, ECUs need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
 

--- a/repositories.md
+++ b/repositories.md
@@ -9,13 +9,13 @@ This page outlines recommended procedures for the one-time operations that an OE
 
 ## Secure Source of Time
 
-Uptane repositories need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a time server can be used in an Uptane implementation.
+Uptane repositories need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
 
 ### Time server
 
 The Time Server exists to inform vehicles about the current time in a cryptographically secure way, since many ECUs in a vehicle will not have a reliable source of time. It receives lists of tokens from vehicles, and returns back a signed sequence that includes the token and the current time.
 
-If the time server is used, it MUST conform to the following requirements:
+If the Time Server is used, it MUST conform to the following requirements:
 
 * When the Time Server receives a sequence of tokens from a vehicle, it SHALL provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
 
@@ -34,32 +34,32 @@ Listing the public key of the Time Server in Director targets metadata is necess
 
 #### Changes to a Primary
 
-If the time server is implemented, the primary SHALL use the following procedure to verify the time. This procedure will occur after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
+If the Time Server is implemented, the primary SHALL use the following procedure to verify the time. This procedure will occur after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
 
 1. Gather the tokens from each secondary ECU's version report.
-2. Send the list of tokens to the time server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
-3. If the time server's response meets the criteria below, update the primary ECU's clock and retain the time server's response for distribution to secondary ECUs, otherwise discard it and proceed without an updated time.  The criteria for checking the time server's response are:
-  - The signature over the time server's response is valid.
-  - The tokens provided to the time server have been included in the response.
-  - The time in the time server's response is later than the last time verified in this manner.
+2. Send the list of tokens to the Time Server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
+3. If the Time Server's response meets the criteria below, update the primary ECU's clock and retain the Time Server's response for distribution to secondary ECUs, otherwise discard it and proceed without an updated time.  The criteria for checking the Time Server's response are:
+  - The signature over the Time Server's response is valid.
+  - The tokens provided to the Time Server have been included in the response.
+  - The time in the Time Server's response is later than the last time verified in this manner.
 
 #### ECU Version Report
 
-The payload of the ECU version report should contain the latest time downloaded from the time server. In addition, the report should include a token (nonce) for the time server to sign and send back.
+The payload of the ECU version report should contain the latest time downloaded from the Time Server. In addition, the report should include a token (nonce) for the Time Server to sign and send back.
 
 #### Changes to all ECUs
 
-At build time, ECUs will be provisioned with an attestation of the current time downloaded from the time server.
+At build time, ECUs will be provisioned with an attestation of the current time downloaded from the Time Server.
 
-As the first step to verifying metadata, described as "Load and verify the current time or the most recent securely attested time" in the Standard, the ECU SHOULD load and verify the  most recent time from the time server using the following procedure:
+As the first step to verifying metadata, described as "Load and verify the current time or the most recent securely attested time" in the Standard, the ECU SHOULD load and verify the  most recent time from the Time Server using the following procedure:
 
 1. Verify that the signatures on the downloaded time are valid.
 2. Verify that the list of nonces/tokens in the downloaded time includes the token that the ECU sent in its previous version report.
 3. Verify that the time downloaded is greater than the previous time.
 
-If all three steps complete without error, the ECU SHALL overwrite its current attested time with the time it has just downloaded, and generate a new nonce/token for the next request to the time server.
+If all three steps complete without error, the ECU SHALL overwrite its current attested time with the time it has just downloaded, and generate a new nonce/token for the next request to the Time Server.
 
-If any check fails, the ECU SHALL NOT overwrite its current attested time, and SHALL jump to the last step ([Create and Send Version Report](https://uptane.github.io/uptane-standard/uptane-standard.html#create_version_report)), and report the error. The ECU MUST reuse its previous token for the next request to the time server.
+If any check fails, the ECU SHALL NOT overwrite its current attested time, and SHALL jump to the last step ([Create and Send Version Report](https://uptane.github.io/uptane-standard/uptane-standard.html#create_version_report)), and report the error. The ECU MUST reuse its previous token for the next request to the Time Server.
 
 #### Changes to checking Root metadata
 

--- a/repositories.md
+++ b/repositories.md
@@ -25,7 +25,7 @@ If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the follo
 
 * The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, HTTPS, or another transport control of the implementor's choice.
 
-* Rotation of the The Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the custom field of the Director Repository's Targets metadata (for partial verification secondaries).
+* Rotation of the the Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the custom field of the Director repository's Targets metadata (for partial verification Secondaries).
 
 #### Changes to the Director repository
 If a Time Server is in use, a representation of the Time Server public key is CONDITIONALLY REQUIRED in Director repository root metadata.

--- a/repositories.md
+++ b/repositories.md
@@ -9,7 +9,7 @@ This page outlines recommended procedures for the one-time operations that an OE
 
 ## Secure Source of Time
 
-Without access to a secure source of time, ECUs may be prevented from receiving the most recent updates. If the ECU's time is too high, the ECU will detect that the current valid metadata is expired and will be unable to perform an update. If the ECU's time is too low, an attacker would be able to replay old metadata to the ECU and install an old, potentially insecure, version.
+Without access to a secure source of time, ECUs may be prevented from receiving the most recent updates. If the ECU's time is too high, the ECU will detect that the current valid metadata is expired and will be unable to perform an update. If the ECU's time is too low, an attacker can prevent time from moving forward significantly to replay old metadata to the ECU.  (ECUs in Uptane will not accept an earlier time than what has been seen before signed with the same key.)
 
 To prevent these issues, ECUs need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
 

--- a/repositories.md
+++ b/repositories.md
@@ -69,7 +69,7 @@ If any check fails, the ECU is CONDITIONALLY REQUIRED to NOT overwrite its curre
 
 #### Changes to checking Root metadata
 
-In order to prevent a new timeserver from accidentally causing a rollback warning, the clock will be reset when switching to a new timeserver. To do this, check the Timeserver key after updating to the most recent Root metadata file. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
+In order to prevent a new Time Server from accidentally causing a rollback warning, the clock will be reset when switching to a new Time Server. To do this, check the Time Server key after updating to the most recent Root metadata file. If the Time Server key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
 
 #### Changes to Partial Verification Secondaries
 

--- a/repositories.md
+++ b/repositories.md
@@ -13,6 +13,8 @@ ECUs need access to a secure source of time. If an ECU does not have a secure cl
 
 ### Time server
 
+A Time Server is a server that is responsible for the distribution of a secure source of time. 
+
 The Time Server exists to inform ECUs about the current time in a cryptographically secure way, since many ECUs in a vehicle do not have a reliable source of time. The Time Server receives a list of tokens from vehicles, and returns back a list of signed records containing every token in the original list of tokens received and at least one instance of the current time.
 
 If the Time Server is used, it MUST conform to the following requirements:

--- a/repositories.md
+++ b/repositories.md
@@ -44,7 +44,7 @@ If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use 
 2. Send the list of tokens to the Time Server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
 3. If the Time Server's response meets the criteria below, update the primary ECU's clock and retain the Time Server's response for distribution to secondary ECUs, otherwise discard it and proceed without an updated time.  The criteria for checking the Time Server's response are:
   - The signature over the Time Server's response is valid.
-  - The tokens provided to the Time Server have been included in the response.
+  - All the tokens provided to the Time Server have been included in the response.
   - The time in the Time Server's response is later than the last time verified in this manner.
 
 #### ECU Version Report

--- a/repositories.md
+++ b/repositories.md
@@ -5,7 +5,7 @@ css_id: repositories
 
 # Setting up Uptane repositories
 
-This page outlines recommended procedures for the one-time operations that an OEM and its suppliers MUST perform when they set up Uptane for the first time. In particular, they SHOULD correctly configure the director and image repositories, as well as the time server, so that the impact of a repository / server compromise is limited to as few ECUs as possible.
+This page outlines recommended procedures for the one-time operations that an OEM and its suppliers SHOULD perform when they set up Uptane for the first time. In particular, they SHOULD correctly configure the director and image repositories, as well as the time server, so that the impact of a repository / server compromise is limited to as few ECUs as possible.
 
 ## Secure Source of Time
 
@@ -19,11 +19,11 @@ A Time Server is a server that is responsible for the distribution of a secure s
 
 The Time Server exists to inform ECUs about the current time in a cryptographically secure way, since many ECUs in a vehicle do not have a reliable source of time. The Time Server receives a list of tokens from vehicles, and returns back a list of signed records containing every token in the original list of tokens received and at least one instance of the current time.
 
-If the Time Server is used, it MUST conform to the following requirements:
+If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the following requirements:
 
-* When the Time Server receives a sequence of tokens from a vehicle, it SHALL provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
+* When the Time Server receives a sequence of tokens from a vehicle, it will provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
 
-* The Time Server SHALL expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
+* The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, or HTTPS.
 
 * Rotation of the The Time Server's key is performed by listing the new key in the Director's Root metadata, in the same manner as other role keys are listed, and also in the Director's Targets metadata (for partial verification secondaries).
 
@@ -38,7 +38,7 @@ Listing the public key of the Time Server in Director targets metadata is necess
 
 #### Changes to a Primary
 
-If the Time Server is implemented, the primary SHALL use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
+If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
 
 1. Gather the tokens from each secondary ECU's version report.
 2. Send the list of tokens to the Time Server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
@@ -49,7 +49,7 @@ If the Time Server is implemented, the primary SHALL use the following procedure
 
 #### ECU Version Report
 
-The payload of the ECU version report should contain the latest time downloaded from the Time Server. In addition, the report should include a token (which MUST be used exactly once) for the Time Server to sign and send back.
+The payload of the ECU version report should contain the latest time downloaded from the Time Server. In addition, the report should include a token (which SHOULD be used exactly once to prevent a replay attack) for the Time Server to sign and send back.
 
 #### Changes to all ECUs
 
@@ -61,17 +61,17 @@ As the first step to verifying metadata, described as "Load and verify the curre
 2. Verify that the list of tokens in the downloaded time includes the token that the ECU sent in its previous version report.
 3. Verify that the time downloaded is greater than the previous time.
 
-If all three steps complete without error, the ECU SHALL overwrite its current attested time with the time it has just downloaded, and generate a new token for the next request to the Time Server.
+If all three steps complete without error, the ECU is CONDITIONALLY REQUIRED to overwrite its current attested time with the time it has just downloaded, and generate a new token for the next request to the Time Server.
 
-If any check fails, the ECU SHALL NOT overwrite its current attested time, and SHALL jump to the last step ([Create and Send Version Report](https://uptane.github.io/uptane-standard/uptane-standard.html#create_version_report)), and report the error. The ECU MUST reuse its previous token for the next request to the Time Server.
+If any check fails, the ECU is CONDITIONALLY REQUIRED to NOT overwrite its current attested time, and jump to the last step ([Create and Send Version Report](https://uptane.github.io/uptane-standard/uptane-standard.html#create_version_report)), and report the error.
 
 #### Changes to checking Root metadata
 
-In order to prevent a new timeserver from accidentally causing a rollback warning, the clock must be reset when switching to a new timeserver. To do this, check the Timeserver key after updating to the most recent Root metadata file. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
+In order to prevent a new timeserver from accidentally causing a rollback warning, the clock will be reset when switching to a new timeserver. To do this, check the Timeserver key after updating to the most recent Root metadata file. If the Timeserver key is listed in the Root metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value (e.g. zero, or any time that is guaranteed to not be in the future based on other evidence).  It will be updated in the next cycle.
 
 #### Changes to Partial Verification Secondaries
 
-As partial verification secondaries only check the Targets metadata from the Director repository, the timeserver key must be checked when verifying the Targets metadata on partial verification secondaries. To do this, check the Timeserver key after verifying the most recent Targets metadata file. If the Timeserver key is listed in the Targets metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value as described in [Changes to checking Root metadata](#changes-to-checking-root-metadata).
+As partial verification secondaries only check the Targets metadata from the Director repository, the timeserver key will be checked when verifying the Targets metadata on partial verification secondaries. To do this, check the Timeserver key after verifying the most recent Targets metadata file. If the Timeserver key is listed in the Targets metadata and has been rotated, reset the clock used to determine the expiration of metadata to a minimal value as described in [Changes to checking Root metadata](#changes-to-checking-root-metadata).
 
 ## What suppliers should do
 

--- a/repositories.md
+++ b/repositories.md
@@ -55,7 +55,7 @@ The payload of the ECU version report sent to the Director might contain the tok
 
 At build time, ECUs will be provisioned with an attestation of the current time downloaded from the Time Server.
 
-As the first step to verifying metadata, described as ["Load and verify the current time or the most recent securely attested time"](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#partial_verification) in the Standard, the ECU SHOULD load and verify the most recent time from the Time Server using the following procedure:
+As the first step to verifying metadata, described for both the [Primary](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#check_time_primary) and [Secondaries](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#verify_time) in the Standard, the ECU SHOULD load and verify the most recent time from the Time Server using the following procedure:
 
 1. Verify that the signatures on the downloaded time are valid.
 2. Verify that the list of tokens in the downloaded time includes the token that the ECU sent in its version report.

--- a/repositories.md
+++ b/repositories.md
@@ -41,7 +41,7 @@ Listing the public key of the Time Server in Director Targets metadata is necess
 If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the ["Download and check current time"](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#check_time_primary) step of the Uptane Standard.
 
 1. Gather the tokens from each secondary ECU's version report.
-2. Send the list of tokens to the Time Server to fetch the current time. The Time Server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
+2. Send the list of tokens to the Time Server to fetch the current time. The Time Server responds as described in the [Time Server section](#time-server), providing a cryptographic attestation of the last known time.
 3. If the Time Server's response meets the criteria below, update the primary ECU's clock and retain the Time Server's response for distribution to secondary ECUs, otherwise discard it and proceed without an updated time.  The criteria for checking the Time Server's response are:
   - The signature over the Time Server's response is valid.
   - All the tokens provided to the Time Server have been included in the response.

--- a/repositories.md
+++ b/repositories.md
@@ -21,7 +21,7 @@ The Time Server exists to inform ECUs about the current time in a cryptographica
 
 If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the following requirements:
 
-* When the Time Server receives a sequence of tokens from a vehicle, it will provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens.
+* When the Time Server receives a sequence of tokens from a vehicle, it will provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens. In the second case, all tokens must be contained in one of the time attestations sent.
 
 * The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, HTTPS, or another transport control of the implementor's choice.
 

--- a/repositories.md
+++ b/repositories.md
@@ -21,7 +21,7 @@ The Time Server exists to inform ECUs about the current time in a cryptographica
 
 If the Time Server is used, it is CONDITIONALLY REQUIRED to conform to the following requirements:
 
-* When the Time Server receives a sequence of tokens from a vehicle, it will provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens. In the second case, all tokens must be contained in one of the time attestations sent.
+* When the Time Server receives a sequence of tokens from a vehicle, it will provide one or more signed responses, containing the time along with these tokens. It MAY produce either one signed time attestation containing the current time and all tokens, or multiple time attestations each containing the current time and one or more tokens. All tokens should be included in the response.
 
 * The Time Server will expose a public interface allowing primaries to communicate with it. This communication MAY occur over FTP, FTPS, SFTP, HTTP, HTTPS, or another transport control of the implementor's choice.
 

--- a/repositories.md
+++ b/repositories.md
@@ -9,11 +9,11 @@ This page outlines recommended procedures for the one-time operations that an OE
 
 ## Secure Source of Time
 
-Uptane repositories need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
+ECUs need access to a secure source of time. If an ECU does not have a secure clock, we recommend the use of a Time Server for time attestations. This section describes how a Time Server can be used in an Uptane implementation.
 
 ### Time server
 
-The Time Server exists to inform vehicles about the current time in a cryptographically secure way, since many ECUs in a vehicle will not have a reliable source of time. It receives lists of tokens from vehicles, and returns back a signed sequence that includes the token and the current time.
+The Time Server exists to inform ECUs about the current time in a cryptographically secure way, since many ECUs in a vehicle do not have a reliable source of time. The Time Server receives a list of tokens from vehicles, and returns back a list of signed records containing every token in the original list of tokens received and at least one instance of the current time.
 
 If the Time Server is used, it MUST conform to the following requirements:
 
@@ -26,7 +26,7 @@ If the Time Server is used, it MUST conform to the following requirements:
 #### Changes to the Director repository
 If a Time Server is in use, a representation of the Time Server public key is CONDITIONALLY REQUIRED in Director repository root metadata.
 
-If a Time Server is implemented AND partial-verification secondaries will be used, the following metadata is CONDITIONALLY REQUIRED in the Director repository's Targets metadata:
+If a Time Server is implemented AND partial-verification secondaries are used, the following metadata is CONDITIONALLY REQUIRED in the Director repository's Targets metadata:
 
 * A representation of the public key(s) for the Time Server, similar to the representation of public keys in Root metadata.
 
@@ -34,7 +34,7 @@ Listing the public key of the Time Server in Director targets metadata is necess
 
 #### Changes to a Primary
 
-If the Time Server is implemented, the primary SHALL use the following procedure to verify the time. This procedure will occur after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
+If the Time Server is implemented, the primary SHALL use the following procedure to verify the time. This procedure occurs after the vehicle version manifest is sent and will fulfill the "Download and check current time" step of the Uptane Standard.
 
 1. Gather the tokens from each secondary ECU's version report.
 2. Send the list of tokens to the Time Server to fetch the current time. The time server responds as described in [Time Server](#time_server), providing a cryptographic attestation of the last known time.
@@ -54,10 +54,10 @@ At build time, ECUs will be provisioned with an attestation of the current time 
 As the first step to verifying metadata, described as "Load and verify the current time or the most recent securely attested time" in the Standard, the ECU SHOULD load and verify the  most recent time from the Time Server using the following procedure:
 
 1. Verify that the signatures on the downloaded time are valid.
-2. Verify that the list of nonces/tokens in the downloaded time includes the token that the ECU sent in its previous version report.
+2. Verify that the list of tokens in the downloaded time includes the token that the ECU sent in its previous version report.
 3. Verify that the time downloaded is greater than the previous time.
 
-If all three steps complete without error, the ECU SHALL overwrite its current attested time with the time it has just downloaded, and generate a new nonce/token for the next request to the Time Server.
+If all three steps complete without error, the ECU SHALL overwrite its current attested time with the time it has just downloaded, and generate a new token for the next request to the Time Server.
 
 If any check fails, the ECU SHALL NOT overwrite its current attested time, and SHALL jump to the last step ([Create and Send Version Report](https://uptane.github.io/uptane-standard/uptane-standard.html#create_version_report)), and report the error. The ECU MUST reuse its previous token for the next request to the Time Server.
 

--- a/repositories.md
+++ b/repositories.md
@@ -49,6 +49,8 @@ If the Time Server is implemented, the primary is CONDITIONALLY REQUIRED to use 
 
 #### ECU Version Report
 
+The ECU version report from each Secondary will contain a token to be sent to the Time Server. This token SHOULD be unique for each update cycle to prevent a replay. As updates are relatively infrequent and there are a large number of possible tokens, the token will be able to be unique for every update.
+
 The payload of the ECU version report sent to the Director might contain the token sent to the Time Server. This token is in the version report sent from secondaries to the primary, and so is in the signed version of the version report. If the token is removed, the signature will not match.
 
 #### Changes to all ECUs


### PR DESCRIPTION
I added the time server description that was removed from the standard in [104]( https://github.com/uptane/uptane-standard/pull/104) to the 'Preparing servers' section. 