### PR TITLE
Removing ASN.1 heading on Deployment Pages

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -57,8 +57,6 @@
       url: /deployment-considerations/customizations.html
     - text: Other security considerations
       url: /deployment-considerations/security_considerations.html
-    - text: ASN.1 examples for metadata syntax
-      url: /deployment-considerations/asn1_examples.html
     - text: Reference Implementation and Demonstration Code
       url: https://github.com/uptane/uptane
       external: true


### PR DESCRIPTION
We decided not to offer examples of ASN.1 metadata as a stand-alone section, but rather to reference and link to examples in the POUF. There is a note with a link at the end of the "Setting up Uptane Repository" page (https://github.com/uptane/deployment-considerations/blob/master/repositories.md#specifying-wireline-formats). So I am removing the title for that Deployment page from the navbar.

I probably don't need a review for this, but wanted it known I was doing it.

Lois