### PR TITLE
Correcting inconsistencies

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -45,9 +45,9 @@
       url: /deployment-considerations/index.html
     - text: Preparing ECUs
       url: /deployment-considerations/ecus.html
-    - text: Preparing servers
+    - text: Setting up Uptane repositories
       url: /deployment-considerations/repositories.html
-    - text: Key management and metadata expiration
+    - text: Managing signing keys and metadata expiration
       url: /deployment-considerations/key_management.html
     - text: Normal operating guidelines
       url: /deployment-considerations/normal_operation.html
@@ -55,7 +55,7 @@
       url: /deployment-considerations/exceptional_operations.html
     - text: Customizing Uptane
       url: /deployment-considerations/customizations.html
-    - text: Other security considerations
+    - text: Additional security recommendations
       url: /deployment-considerations/security_considerations.html
     - text: Reference Implementation and Demonstration Code
       url: https://github.com/uptane/uptane


### PR DESCRIPTION
This PR proposes consistent titles to be used on both the pull down menu and the deployment page titles. As it is now, there are number of inconsistencies on what the page is called in the pull down menu as opposed to what the user sees when the page opens. I see no reason why these content pieces shouldn't be titled the same way in both places.

Please suggest any necessary tweaks, and then I will edit the pages accordingly, and update the navbar on the website.

Thanks.