### PR TITLE
ecus.md: Add more explanation to partial verification options.

### DIFF
--- a/ecus.md
+++ b/ecus.md
@@ -24,8 +24,10 @@ Uptane is designed with automotive requirements in mind, and one of the difficul
 
 Firstly, if the ECU is a Primary ECU, partial verification is not an option. Primaries need to perform full verification. For other ECUs, full verification is preferable when possible, for at least two reasons:
 
-1. Full verification is more secure. Because they don't check image repository metadata, partial verification ECUS could be instructed to install malicious software by an attacker in possession of the Director repository's Targets key (and, of course, a way to send traffic on the relevant in-vehicle bus).
-2. Full verification ECUs can rotate keys. Because partial verification is designed for ECUs that can only reasonably check a single signature, they do not download or process root metadata. Since the root metadata is the mechanism for revoking and rotating signing keys for all other metadata, a partial verification ECU has no truly secure way to invalidate a signing key.
+1. Full verification is more secure. Because they don't check Image repository metadata, partial verification ECUS could be instructed to install malicious software by an attacker in possession of the Director repository's Targets key (and, of course, a way to send traffic on the relevant in-vehicle bus).
+2. Full verification ECUs can rotate keys. Because partial verification is designed for ECUs that can only reasonably check a single signature, they do not download or process Root metadata. Since the Root metadata is the mechanism for revoking and rotating signing keys for all other metadata, a partial verification ECU has no truly secure way to invalidate a signing key.
+
+Partial verification ECUs are expected to have the Root and Targets metadata present at the time of manufacturing or installation in the vehicle. To update the Root metadata, the ECU SHOULD install a new image containing the metadata. To update the Targets metadata, the ECU SHOULD follow the steps described in the [Uptane standard](https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#partial_verification). Partial verification Secondaries MAY additionally fetch and check metadata from other roles or the Image repository if the ECU is powerful enough to process them and you wish to take advantage of their respective security benefits.
 
 ### Symmetric vs. asymmetric ECU keys
 


### PR DESCRIPTION
* Better explain how Root and Targets metadata are actually handled. This is mostly covered in the Standard, but this make it more explicit and in one place.

* Allow for using additional metadata if desired. Still fairly vague, but I just wanted to make the option explicitly available.

Closes https://github.com/uptane/deployment-considerations/issues/40 and also helps address some of the lingering bits of https://github.com/uptane/uptane-standard/issues/152.