### PR TITLE
Glossary changes based on @pattivacek comments--addresses Issue #83

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -5,11 +5,6 @@ css_id: glossary
 
 # Glossary
 
-### Conformance terminology
-The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in {{RFC2119}}.
-
-In order to be considered Uptane-compliant, an implementation MUST follow all of these rules as specified in the document.
-
 ### Terminology
 
 *Bundle:* A set of images released by the repository that is meant to be installed by one or more ECUs on a vehicle during the same update cycle.
@@ -38,8 +33,6 @@ In order to be considered Uptane-compliant, an implementation MUST follow all of
 
 ### Uptane role terminology
 
-These terms are defined in greater detail in {{roles}}.
-
 *Delegation:* A process by which the responsibility of signing metadata about images is assigned to another party. 
 
 *Role:* A party (human or machine) responsible for signing a certain type of metadata. The role controls keys and is responsible for signing metadata entrusted to it with these keys. The roles mechanism of Uptane allows the system to distribute signing responsibilities so that the compromise of one key does not necessarily impact the security of the entire system.
@@ -51,20 +44,4 @@ These terms are defined in greater detail in {{roles}}.
 * *Targets role:* Signs metadata used to verify the image, such as cryptographic hashes and file size.
 
 * *Timestamp role:* Signs metadata that indicates if there are any new metadata or images on the repository.
-
-### Acronyms and abbreviations
-
-*CDN:* Content Delivery Network
-
-*ECUs:* Electronic Control Units, the computing units on a vehicle
-
-*LIN Bus:* Local Interconnect Bus
-
-*OBD:* On-board diagnostics
-
-*SOTA:* Software Updates Over-the-Air
-
-*UDS:* Unified Diagnostic Services
-
-*VIN:* Vehicle Identification Number
 

--- a/glossary.md
+++ b/glossary.md
@@ -5,6 +5,12 @@ css_id: glossary
 
 # Glossary
 
+### Conformance terminology
+
+The keywords MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in {{RFC2119}}.
+
+In order to be considered Uptane-compliant, an implementation MUST follow all of these rules as specified in the document.
+
 ### Terminology
 
 *Bundle:* A set of images released by the repository that is meant to be installed by one or more ECUs on a vehicle during the same update cycle.


### PR DESCRIPTION
I had added text to the glossary based on comments @pattivacek  made on an earlier draft of this PR (which I accidentally merged directly).   I am opening this PR in part to act on those suggestions, and also to solicit changes based on a more fundamental question raised by @pattivacek. I am particularly directing this to @iramcdonald, but others are welcomed to chime in.

 What appears here is essentially the same glossary as in the Standard. I have not included the explanation of  Conformance Terminology, as these pages use much less of it than the Standard, and @pattivacek noted that none of the acronyms in that list appear in the Deployment pages. I also eliminated  some one-sentence introductory text that didn't feel needed in this context.  Is this what we need for such a section in Deployment Best Practices? Or do we need to evolve new terminology for this document? Perhaps we need to cull the pages.

I would appreciate your thoughts, as well as those of others on the team.