### PR TITLE
Added information for V 1.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-07-2
+As this is the second minor release issued in 2021, the short list of changes made to the Uptane Standard between January 8 and July 2 of this year primarily are wordsmithing corrections to improve clarity. As a result, the majority of the text edits and additions seek to correct wording in the original text that could potentially be misleading. Several of these changes 
+
+### Added
+
+- A "SHOULD" requirement to the Standard about including vehicle identifiers to help avoid replay attacks. The sentence "Targets metadata from the Director repository SHOULD include a vehicle identifier if there are no images included in the targets metadata" was added to Section 5.2.3.1.
+
+- Added the word "unique" wherever the Standard mentions key thresholds. This is to clarify that multiple signatures from the same key do not count as a threshold. 
+
+### Changed
+
+- The location of the "Terminology" sections. All necessary definitions have been moved to the Glossary section of the Deployment Best Practices document.
+
+### Removed
+
+- The use of the phrase "secondary storage," because this usage was very unclear. Instead, the Standard now refers to secondaries with "limited storage to receive an image." 
+
 
 ## [1.1.0] - 2021-01-08
 The changes made to the Uptane Standard since its initial release on July 31, 2019, have principally addressed issues of style, clarity, and the resolution of inconsistencies. As a result, the majority of text edits and additions seek to correct wording in the original text that could potentially be misleading.


### PR DESCRIPTION
This includes the few changes made to the Standard.

I can't remember if the initial changelog registered changes made to the Deployment Best Practices document. A huge number of changes were to those pages over the past six months. Can somebody weigh in on whether these changes need to be added as well?